### PR TITLE
Improve DPL's sorting behavior for table columns that are nearly numeric

### DIFF
--- a/includes/ParametersData.php
+++ b/includes/ParametersData.php
@@ -127,6 +127,7 @@ class ParametersData {
 			'table',
 			'tablerow',
 			'tablesortcol',
+			'tablesortmethod',
 			'titlematch',
 			'usedby',
 			'uses'
@@ -1103,6 +1104,16 @@ class ParametersData {
 		'tablesortcol' => [
 			'default'	=> null,
 			'integer'	=> true
+		],
+		/**
+		 * The sorting algorithm for table columns when 'tablesortcol'
+		 * is used.
+		 * - standard: Use PHP asort() and arsort()
+		 * - natural: Use PHP natsort()
+		 */
+		'tablesortmethod' => [
+			'default'	=> null,
+			'values'	=> ['standard', 'natural']
 		],
 		/**
 		 * Max # characters of page title to display.

--- a/includes/lister/Lister.php
+++ b/includes/lister/Lister.php
@@ -256,6 +256,7 @@ class Lister {
 		$this->setTemplateSuffix( $parameters->getParameter( 'defaulttemplatesuffix' ) );
 		$this->setTrimIncluded( $parameters->getParameter( 'includetrim' ) );
 		$this->setTableSortColumn( $parameters->getParameter( 'tablesortcol' ) );
+		$this->setTableSortMethod($parameters->getParameter('tablesortmethod'));
 		$this->setTitleMaxLength( $parameters->getParameter( 'titlemaxlen' ) );
 		$this->setEscapeLinks( $parameters->getParameter( 'escapelinks' ) );
 		$this->setSectionSeparators( $parameters->getParameter( 'secseparators' ) );
@@ -481,6 +482,27 @@ class Lister {
 	 */
 	public function getTableSortColumn() {
 		return $this->tableSortColumn;
+	}
+
+	/**
+	 * Set the algorithm for table sorting
+	 *
+	 * @access	public
+	 * @param	string	Algorithm name
+	 * @return	void
+	 */
+	public function setTableSortMethod($method = null) {
+		$this->tableSortMethod = $method === null ? 'standard' : $method;
+	}
+
+	/**
+	 * Get the algorithm for table sorting
+	 *
+	 * @access	public
+	 * @return	string	Algorithm name
+	 */
+	public function getTableSortMethod() {
+		return $this->tableSortMethod;
 	}
 
 	/**

--- a/includes/lister/UserFormatList.php
+++ b/includes/lister/UserFormatList.php
@@ -114,11 +114,7 @@ class UserFormatList extends Lister {
 					}
 				}
 			}
-			if ( $sortColumn < 0 ) {
-				arsort( $rowsKey );
-			} else {
-				asort( $rowsKey );
-			}
+			$this->sort($rowsKey, $sortColumn);
 			$newItems = [];
 			foreach ( $rowsKey as $index => $val ) {
 				$newItems[] = $items[$index];
@@ -127,6 +123,43 @@ class UserFormatList extends Lister {
 		}
 
 		return $this->listStart . $this->implodeItems( $items ) . $this->listEnd;
+	}
+
+	/**
+	 * Sort the data of a table column in place. Preserves array keys.
+	 *
+	 * @access	public
+	 * @param	array	Table column data
+	 * @param	int		Index of the column to sort
+	 * @return	void
+	 */
+	protected function sort(&$rowsKey, $sortColumn) {
+		$sortMethod = $this->getTableSortMethod();
+	
+		if ($sortColumn < 0) {
+			switch ($sortMethod) {
+				case 'natural':
+				// Reverse natsort()
+				   uasort($rowsKey, function($a, $b) {
+				   return strnatcmp($b, $a);
+				});
+				break;
+				case 'standard':
+				default:
+					arsort($rowsKey);
+					break;
+			}
+		} else {
+			switch ($sortMethod) {
+				case 'natural':
+				natsort($rowsKey);
+				break;
+			case 'standard':
+			default:
+				asort($rowsKey);
+				break;
+			}
+		}
 	}
 
 	/**

--- a/includes/lister/UserFormatList.php
+++ b/includes/lister/UserFormatList.php
@@ -139,11 +139,11 @@ class UserFormatList extends Lister {
 		if ($sortColumn < 0) {
 			switch ($sortMethod) {
 				case 'natural':
-				// Reverse natsort()
-				   uasort($rowsKey, function($a, $b) {
-				   return strnatcmp($b, $a);
-				});
-				break;
+					// Reverse natsort()
+                    uasort($rowsKey, function($first, $second) {
+                    	return strnatcmp($second, $first);
+					});
+					break;
 				case 'standard':
 				default:
 					arsort($rowsKey);


### PR DESCRIPTION
DPL's sorting behavior for tables is buggy for numeric columns when the data is not quite numeric, as shown in the example below. This change allows DPL to use PHP `natsort()` optionally instead of `asort/arsort()` when sorting a table column. `natsort()` handles nearly-numeric data correctly.

This change introduces a new keyword, `tablesortmethod`, with values `standard` (the default, which preserves DPL's existing behavior) and `natural` (which uses natsort()).

Example: If a table column contains these numeric strings:

```
$arr[] = ['103', '103-104', '100', '99', '105'];
```

DPL's current behavior uses `asort()`, which sorts the values bizarrely like this:

```
Array
(
    [2] => 100
    [0] => 103
    [1] => 103-104
    [3] => 99
    [4] => 105
)
```

but `natsort()` sorts them intuitively like this:

```
Array
(
    [3] => 99
    [2] => 100
    [0] => 103
    [1] => 103-104
    [4] => 105
)
```

[sorting-demo.php.txt](https://github.com/Universal-Omega/DynamicPageList3/files/6765570/sorting-demo.php.txt)

I implemented the change to be backward compatible; when the `tablesortmethod` keyword is not present, DPL's behavior is unchanged.