### PR TITLE
Fix setting query limit

### DIFF
--- a/includes/Query.php
+++ b/includes/Query.php
@@ -213,7 +213,7 @@ class Query {
 		if ( $this->limit !== false ) {
 			$options['LIMIT'] = $this->limit;
 		} elseif ( $this->offset !== false && $this->limit === false ) {
-			$options['LIMIT'] = $this->parameters->getData( 'count' )['default'];
+			$options['LIMIT'] = $this->parameters->getParameter( 'count' );
 		}
 
 		if ( $this->parameters->getParameter( 'openreferences' ) ) {


### PR DESCRIPTION
Should fix the issue where `$wgDplSettings['allowUnlimitedResults']`, `$wgDplSettings['maxResultCount']`, and the `count` parameter are having no effect when trying to get more than 500 results.