### PR TITLE
Remove unused 'dpl_description' i18n message

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -34,7 +34,6 @@
 	"dpl_log_21": "Query: <code>$0</code>",
 	"dpl_log_22": "Warning: No parameter option supplied for '$1'. (Missing '=')",
 	"dpl_articlecount": "There {{PLURAL:$1|is one article|are $1 articles}} in this heading.",
-	"dpl_description": "A flexible report generator for MediaWiki. See [http://semeb.com/dpldemo] for the manual and examples",
 	"action-dpl_param_update_rules": "to use the parameter 'updaterules'",
 	"action-dpl_param_delete_rules": "to use the parameter 'deleterules'",
 	"dpl_query_error": "The DPL extension (version $1) produced a SQL statement which led to a Database error.<br/>The reason may be an internal error of DPL or an error which you made; especially when using parameters like 'categoryregexp' or 'titleregexp'. Usage of non-greedy *? matching patterns are not supported.<br/>Error message was:<br/><tt>$2</tt>",


### PR DESCRIPTION
The extension.json file uses the key 'dpl-desc' instead. This old message referenced a website which nowadays has nothing to do with MediaWiki.