### PR TITLE
Fix second param to `preg_match`

### DIFF
--- a/includes/Parameters.php
+++ b/includes/Parameters.php
@@ -407,7 +407,7 @@ class Parameters extends ParametersData {
 			// would throw an error due to a bad regex from user input.
 
 			// phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
-			if ( @preg_match( $regex, null ) === false ) {
+			if ( @preg_match( $regex, '' ) === false ) {
 				// @phan-suppress-previous-line PhanParamSuspiciousOrder, PhanTypeMismatchArgumentInternalProbablyReal
 				return false;
 			}


### PR DESCRIPTION
The function `preg_match` requires as string a second parameter. Issue found by `phan` check.