### PR TITLE
Restore MediaWiki 1.35 compatibility

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "DynamicPageList3",
-	"version": "3.3.7",
+	"version": "3.3.8",
 	"author": [
 		"Alexia E. Smith",
 		"[https://meta.miraheze.org/wiki/User:Universal_Omega Universal Omega]",
@@ -11,7 +11,7 @@
 	"license-name": "GPL-3.0-or-later",
 	"type": "parserhook",
 	"requires": {
-		"MediaWiki": ">= 1.36.0"
+		"MediaWiki": ">= 1.35.0"
 	},
 	"GroupPermissions": {
 		"sysop": {

--- a/includes/UpdateArticle.php
+++ b/includes/UpdateArticle.php
@@ -394,9 +394,16 @@ class UpdateArticle {
 		$permission_errors = MediaWikiServices::getInstance()->getPermissionManager()->getPermissionErrors( 'edit', $user, $titleX );
 
 		if ( count( $permission_errors ) == 0 ) {
-			$wikiPageFactory = MediaWikiServices::getInstance()->getWikiPageFactory();
+			$services = MediaWikiServices::getInstance();
+			// MW 1.36+
+			if ( method_exists( $services, 'getWikiPageFactory' ) ) {
+				$wikiPageFactory = $services->getWikiPageFactory();
+				$page = $wikiPageFactory->newFromTitle( $titleX );
+			}
+			else {
+				$page = \WikiPage::factory( $titleX );
+			}
 
-			$page = $wikiPageFactory->newFromTitle( $titleX );
 			$updater = $page->newPageUpdater( $user );
 			$content = $page->getContentHandler()->makeContent( $text, $titleX );
 			$updater->setContent( SlotRecord::MAIN, $content );

--- a/maintenance/createTemplate.php
+++ b/maintenance/createTemplate.php
@@ -55,9 +55,15 @@ class CreateTemplate extends LoggedUpdateMaintenance {
 
 		// Make sure template does not already exist
 		if ( !$title->exists() ) {
-			$wikiPageFactory = MediaWikiServices::getInstance()->getWikiPageFactory();
-
-			$page = $wikiPageFactory->newFromTitle( $title );
+			$services = MediaWikiServices::getInstance();
+			// MW 1.36+
+			if ( method_exists( $services, 'getWikiPageFactory' ) ) {
+				$wikiPageFactory = $services->getWikiPageFactory();
+				$page = $wikiPageFactory->newFromTitle( $title );
+			}
+			else {
+				$page = \WikiPage::factory( $title );
+			}
 			$updater = $page->newPageUpdater( User::newSystemUser( 'DynamicPageList3 extension' ) );
 			$content = $page->getContentHandler()->makeContent( '<noinclude>This page was automatically created. It serves as an anchor page for all \'\'\'[[Special:WhatLinksHere/Template:Extension_DPL|invocations]]\'\'\' of [https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:DynamicPageList3 Extension:DynamicPageList3].</noinclude>', $title );
 			$updater->setContent( SlotRecord::MAIN, $content );


### PR DESCRIPTION
I have checked the code of 3.3.7 for incompatibilities with MediaWiki 1.35. Those were the only issues I could identify. I also performed a couple of manual function testing.

See also
- https://github.com/Universal-Omega/DynamicPageList3/issues/69
- https://github.com/Universal-Omega/DynamicPageList3/issues/75