### PR TITLE
Fix path to `Maintenance.php`

### DIFF
--- a/maintenance/createTemplate.php
+++ b/maintenance/createTemplate.php
@@ -11,7 +11,7 @@ use User;
 
 $IP = getenv( 'MW_INSTALL_PATH' );
 if ( $IP === false ) {
-	$IP = __DIR__ . '/../../../..';
+	$IP = __DIR__ . '/../../..';
 }
 
 require_once "$IP/maintenance/Maintenance.php";


### PR DESCRIPTION
This fix is probably not required as this script usually gets run automatically by `update.php`. Still, If one tries to run it manually it will fail with 

```
PHP Fatal error:  Uncaught Error: Failed opening required '.../extensions/DynamicPageList/maintenance/../../../../maintenance/Maintenance.php' (include_path='.:/usr/local/lib/php') in .../extensions/DynamicPageList/maintenance/createTemplate.php:17
```