### PR TITLE
Add support for `openreferences=missing`

### DIFF
--- a/includes/Parameters.php
+++ b/includes/Parameters.php
@@ -286,7 +286,7 @@ class Parameters extends ParametersData {
 
 		$parameters = $this->getParametersForRichness();
 		foreach ( $parameters as $parameter ) {
-			if ( $this->getData( $parameter )['default'] !== null && !( $this->getData( $parameter )['default'] === false && $this->getData( $parameter )['boolean'] === true ) ) {
+			if ( $this->getData( $parameter )['default'] !== null && !( $this->getData( $parameter )['default'] === false && ( $this->getData( $parameter )['boolean'] ?? false ) === true ) ) {
 				if ( $parameter == 'debug' ) {
 					DynamicPageListHooks::setDebugLevel( $this->getData( $parameter )['default'] );
 				}

--- a/includes/Parameters.php
+++ b/includes/Parameters.php
@@ -724,7 +724,9 @@ class Parameters extends ParametersData {
 	 * @return bool
 	 */
 	public function _openreferences( $option ) {
-		$option = $this->filterBoolean( $option );
+		if ( $option !== 'missing' ) {
+			$option = $this->filterBoolean( $option );
+		}
 
 		if ( $option === null ) {
 			return false;

--- a/includes/Parameters.php
+++ b/includes/Parameters.php
@@ -408,7 +408,7 @@ class Parameters extends ParametersData {
 
 			// phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
 			if ( @preg_match( $regex, '' ) === false ) {
-				// @phan-suppress-previous-line PhanParamSuspiciousOrder, PhanTypeMismatchArgumentInternalProbablyReal
+				// @phan-suppress-previous-line PhanParamSuspiciousOrder
 				return false;
 			}
 		}

--- a/includes/ParametersData.php
+++ b/includes/ParametersData.php
@@ -932,6 +932,7 @@ class ParametersData {
 		 * openreferences =...
 		 * - no: excludes pages which do not exist (=default)
 		 * - yes: includes pages which do not exist -- this conflicts with some other options
+		 * - missing: includes only pages which do not exist -- this conflicts with some other options
 		 */
 		'openreferences' => [
 			'default' => false,

--- a/includes/ParametersData.php
+++ b/includes/ParametersData.php
@@ -935,8 +935,7 @@ class ParametersData {
 		 * - missing: includes only pages which do not exist -- this conflicts with some other options
 		 */
 		'openreferences' => [
-			'default' => false,
-			'boolean' => true
+			'default' => false
 		],
 		/**
 		 * redirects =...

--- a/includes/Parse.php
+++ b/includes/Parse.php
@@ -394,6 +394,13 @@ class Parse {
 					$pageNamespace = $row['pl_namespace'];
 					$pageTitle = $row['pl_title'];
 				}
+
+				if (
+					$this->parameters->getParameter( 'openreferences' ) === 'missing' &&
+					Title::makeTitle( $pageNamespace, $pageTitle )->exists()
+				) {
+					continue;
+				}
 			} else {
 				// Existing PAGE TITLE
 				$pageNamespace = $row['page_namespace'];

--- a/includes/Parse.php
+++ b/includes/Parse.php
@@ -222,7 +222,7 @@ class Parse {
 			return $this->getFullOutput();
 		}
 
-		$numRows = $this->DB->numRows( $result );
+		$numRows = $result->numRows();
 		$articles = $this->processQueryResults( $result, $parser );
 
 		global $wgDebugDumpSql;
@@ -352,7 +352,7 @@ class Parse {
 		/*******************************/
 		$randomCount = $this->parameters->getParameter( 'randomcount' );
 		if ( $randomCount > 0 ) {
-			$nResults = $this->DB->numRows( $result );
+			$nResults = $result->numRows();
 			// mt_srand() seeding was removed due to PHP 5.2.1 and above no longer generating the same sequence for the same seed.
 			//Constrain the total amount of random results to not be greater than the total results.
 			if ( $randomCount > $nResults ) {

--- a/includes/Parse.php
+++ b/includes/Parse.php
@@ -242,7 +242,7 @@ class Parse {
 		/*********************/
 		if ( $numRows <= 0 || empty( $articles ) ) {
 			// Shortcut out since there is no processing to do.
-			$this->DB->freeResult( $result );
+			$result->free();
 			return $this->getFullOutput( 0, false );
 		}
 
@@ -423,7 +423,7 @@ class Parse {
 			$articles[] = Article::newFromRow( $row, $this->parameters, $title, $pageNamespace, $pageTitle );
 		}
 
-		$this->DB->freeResult( $result );
+		$result->free();
 
 		return $articles;
 	}

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -322,9 +322,9 @@ class Query {
 
 			if ( $calcRows ) {
 				$calcRowsResult = $this->DB->query( 'SELECT FOUND_ROWS() AS rowcount', __METHOD__ );
-				$total = $this->DB->fetchRow( $calcRowsResult );
+				$total = $calcRowsResult->fetchRow();
 				$this->foundRows = intval( $total['rowcount'] );
-				$this->DB->freeResult( $calcRowsResult );
+				$calcRowsResult->free();
 			}
 		} catch ( Exception $e ) {
 			$queryError = true;
@@ -661,7 +661,7 @@ class Query {
 		}
 
 		$categories = array_unique( $categories );
-		$DB->freeResult( $result );
+		$result->free();
 
 		return $categories;
 	}

--- a/includes/UpdateArticle.php
+++ b/includes/UpdateArticle.php
@@ -9,6 +9,7 @@ use MediaWiki\Revision\SlotRecord;
 use ReadOnlyError;
 use RequestContext;
 use Title;
+use WikiPage;
 
 class UpdateArticle {
 	/**
@@ -400,7 +401,8 @@ class UpdateArticle {
 				$wikiPageFactory = $services->getWikiPageFactory();
 				$page = $wikiPageFactory->newFromTitle( $titleX );
 			} else {
-				$page = \WikiPage::factory( $titleX );
+				// @phan-suppress-next-line PhanDeprecatedFunction
+				$page = WikiPage::factory( $titleX );
 			}
 
 			$updater = $page->newPageUpdater( $user );

--- a/includes/UpdateArticle.php
+++ b/includes/UpdateArticle.php
@@ -399,8 +399,7 @@ class UpdateArticle {
 			if ( method_exists( $services, 'getWikiPageFactory' ) ) {
 				$wikiPageFactory = $services->getWikiPageFactory();
 				$page = $wikiPageFactory->newFromTitle( $titleX );
-			}
-			else {
+			} else {
 				$page = \WikiPage::factory( $titleX );
 			}
 

--- a/includes/Variables.php
+++ b/includes/Variables.php
@@ -3,7 +3,6 @@
 namespace DPL;
 
 class Variables {
-
 	/**
 	 * Memory storage for variables.
 	 *

--- a/includes/Variables.php
+++ b/includes/Variables.php
@@ -3,6 +3,7 @@
 namespace DPL;
 
 class Variables {
+
 	/**
 	 * Memory storage for variables.
 	 *

--- a/maintenance/createTemplate.php
+++ b/maintenance/createTemplate.php
@@ -8,6 +8,7 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\SlotRecord;
 use Title;
 use User;
+use WikiPage;
 
 $IP = getenv( 'MW_INSTALL_PATH' );
 if ( $IP === false ) {
@@ -61,7 +62,8 @@ class CreateTemplate extends LoggedUpdateMaintenance {
 				$wikiPageFactory = $services->getWikiPageFactory();
 				$page = $wikiPageFactory->newFromTitle( $title );
 			} else {
-				$page = \WikiPage::factory( $title );
+				// @phan-suppress-next-line PhanDeprecatedFunction
+				$page = WikiPage::factory( $title );
 			}
 			$updater = $page->newPageUpdater( User::newSystemUser( 'DynamicPageList3 extension' ) );
 			$content = $page->getContentHandler()->makeContent( '<noinclude>This page was automatically created. It serves as an anchor page for all \'\'\'[[Special:WhatLinksHere/Template:Extension_DPL|invocations]]\'\'\' of [https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:DynamicPageList3 Extension:DynamicPageList3].</noinclude>', $title );

--- a/maintenance/createTemplate.php
+++ b/maintenance/createTemplate.php
@@ -60,8 +60,7 @@ class CreateTemplate extends LoggedUpdateMaintenance {
 			if ( method_exists( $services, 'getWikiPageFactory' ) ) {
 				$wikiPageFactory = $services->getWikiPageFactory();
 				$page = $wikiPageFactory->newFromTitle( $title );
-			}
-			else {
+			} else {
 				$page = \WikiPage::factory( $title );
 			}
 			$updater = $page->newPageUpdater( User::newSystemUser( 'DynamicPageList3 extension' ) );


### PR DESCRIPTION
Add support for `openreferences=missing` to display only missing page titles with `openreferences`.

* Requested: #50 