### PR TITLE
Use the existing Services object

### DIFF
--- a/includes/Article.php
+++ b/includes/Article.php
@@ -230,9 +230,7 @@ class Article {
 
 		$article->mLink = $articleLink;
 
-		$languageConverter = MediaWikiServices::getInstance()
-			->getLanguageConverterFactory()
-			->getLanguageConverter();
+		$languageConverter = $services->getLanguageConverterFactory()->getLanguageConverter();
 
 		// get first char used for category-style output
 		if ( isset( $row['sortkey'] ) ) {


### PR DESCRIPTION
It was already defined above, on line 198.

Also compacted the multi-line chained method calls into one line since its length does not exceed 120 characters.