### PR TITLE
Fix `openreferences=missing` count

### DIFF
--- a/includes/Parse.php
+++ b/includes/Parse.php
@@ -383,20 +383,13 @@ class Parse {
 				$pageNamespace = NS_CATEGORY;
 				$pageTitle = $row->cl_to;
 			} elseif ( $this->parameters->getParameter( 'openreferences' ) ) {
-				if ( count( $this->parameters->getParameter( 'imagecontainer' ) ) > 0 ) {
+				if ( count( $this->parameters->getParameter( 'imagecontainer' ) ?? [] ) > 0 ) {
 					$pageNamespace = NS_FILE;
 					$pageTitle = $row->il_to;
 				} else {
 					// Maybe non-existing title
 					$pageNamespace = $row->pl_namespace;
 					$pageTitle = $row->pl_title;
-				}
-
-				if (
-					$this->parameters->getParameter( 'openreferences' ) === 'missing' &&
-					Title::makeTitle( $pageNamespace, $pageTitle )->exists()
-				) {
-					continue;
 				}
 			} else {
 				// Existing PAGE TITLE

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -228,7 +228,7 @@ class Query {
 		}
 
 		if ( $this->parameters->getParameter( 'openreferences' ) ) {
-			if ( count( $this->parameters->getParameter( 'imagecontainer' ) ) > 0 ) {
+			if ( count( $this->parameters->getParameter( 'imagecontainer' ) ?? [] ) > 0 ) {
 				$tables = [
 					'ic' => 'imagelinks'
 				];

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -251,7 +251,7 @@ class Query {
 
 					$this->addWhere(
 						[
-							'page_namespace' => null,
+							$this->tableNames['page'] . 'page_namespace' => null,
 						]
 					);
 

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -245,7 +245,7 @@ class Query {
 				];
 
 				if ( $this->parameters->getParameter( 'openreferences' ) === 'missing' ) {
-					$tables += [	
+					$tables += [
 						'page',
 					];
 

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -251,8 +251,8 @@ class Query {
 
 					$this->addSelect(
 						[
-							'page_namespace',
-							'page_title',
+							'page_namespace' => $this->tableNames['page'] . '.page_namespace',
+							'page_title' => $this->tableNames['page'] . '.page_title',
 						]
 					);
 

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -253,6 +253,7 @@ class Query {
 					$this->addSelect(
 						[
 							'page_namespace' => $this->tableNames['page'] . '.page_namespace',
+							'page_id' => $this->tableNames['page'] . '.page_id',
 							'page_title' => $this->tableNames['page'] . '.page_title',
 						]
 					);

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -245,8 +245,9 @@ class Query {
 				];
 
 				if ( $this->parameters->getParameter( 'openreferences' ) === 'missing' ) {
-					$tables += [
+					$tables = [
 						'page',
+						'pagelinks',
 					];
 
 					$this->addSelect(

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -249,9 +249,16 @@ class Query {
 						'page',
 					];
 
+					$this->addSelect(
+						[
+							'page_namespace',
+							'page_title',
+						]
+					);
+
 					$this->addWhere(
 						[
-							$this->tableNames['page'] . 'page_namespace' => null,
+							'page_namespace' => null,
 						]
 					);
 

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -233,28 +233,14 @@ class Query {
 					'ic' => 'imagelinks'
 				];
 			} else {
-				$this->addSelect(
-					[
-						'pl_namespace',
-						'pl_title'
-					]
-				);
-
-				$tables = [
-					'pagelinks'
-				];
-
 				if ( $this->parameters->getParameter( 'openreferences' ) === 'missing' ) {
-					$tables = [
-						'page',
-						'pagelinks',
-					];
-
 					$this->addSelect(
 						[
-							'page_namespace' => $this->tableNames['page'] . '.page_namespace',
-							'page_id' => $this->tableNames['page'] . '.page_id',
-							'page_title' => $this->tableNames['page'] . '.page_title',
+							'page_namespace',
+							'page_id',
+							'page_title',
+							'pl_namespace',
+							'pl_title',
 						]
 					);
 
@@ -274,6 +260,22 @@ class Query {
 							],
 						]
 					);
+
+					$tables = [
+						'page',
+						'pagelinks',
+					];
+				} else {
+					$this->addSelect(
+						[
+							'pl_namespace',
+							'pl_title',
+						]
+					);
+
+					$tables = [
+						'pagelinks',
+					];
 				}
 			}
 		} else {

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -243,6 +243,29 @@ class Query {
 				$tables = [
 					'pagelinks'
 				];
+
+				if ( $this->parameters->getParameter( 'openreferences' ) === 'missing' ) {
+					$tables += [	
+						'page',
+					];
+
+					$this->addWhere(
+						[
+							'page_namespace' => null,
+						]
+					);
+
+					$this->addJoin(
+						'page',
+						[
+							'LEFT JOIN',
+							[
+								'page_namespace = pl_namespace',
+								'page_title = pl_title',
+							],
+						]
+					);
+				}
 			}
 		} else {
 			$tables = $this->tables;

--- a/tests/phpunit/DPLQueryIntegrationTest.php
+++ b/tests/phpunit/DPLQueryIntegrationTest.php
@@ -49,7 +49,7 @@ class DPLQueryIntegrationTest extends DPLIntegrationTestCase {
 			// NS_MAIN
 			'namespace' => '',
 			'titlematch' => 'DPLTest%',
-			'notcategory' => 'DPLTestCategory',
+			'notcategory' => 'DPLTestCategory'
 		] );
 
 		$this->assertArrayEquals(

--- a/tests/phpunit/DPLQueryIntegrationTest.php
+++ b/tests/phpunit/DPLQueryIntegrationTest.php
@@ -335,4 +335,20 @@ class DPLQueryIntegrationTest extends DPLIntegrationTestCase {
 			'DPLTestArticleMultipleCategories DPLTestAdmin',
 		], $results );
 	}
+
+	public function testOpenReferences(): void {
+		$results = $this->getDPLQueryResults( [
+			'namespace' => '',
+			'openreferences' => 'missing',
+			'count' => 1
+		] );
+
+		$this->assertArrayEquals(
+			[
+				'RedLink',
+			],
+			$results,
+			true
+		);
+	}
 }

--- a/tests/phpunit/DPLQueryIntegrationTest.php
+++ b/tests/phpunit/DPLQueryIntegrationTest.php
@@ -335,7 +335,6 @@ class DPLQueryIntegrationTest extends DPLIntegrationTestCase {
 			'DPLTestArticle 2 DPLTestAdmin',
 			'DPLTestArticle 3 DPLTestAdmin',
 			'DPLTestArticleMultipleCategories DPLTestAdmin',
-			'DPLTestOpenReferences DPLTestUser',
 		], $results );
 	}
 

--- a/tests/phpunit/DPLQueryIntegrationTest.php
+++ b/tests/phpunit/DPLQueryIntegrationTest.php
@@ -333,6 +333,7 @@ class DPLQueryIntegrationTest extends DPLIntegrationTestCase {
 			'DPLTestArticle 2 DPLTestAdmin',
 			'DPLTestArticle 3 DPLTestAdmin',
 			'DPLTestArticleMultipleCategories DPLTestAdmin',
+			'DPLTestOpenReferences DPLTestUser',
 		], $results );
 	}
 

--- a/tests/phpunit/DPLQueryIntegrationTest.php
+++ b/tests/phpunit/DPLQueryIntegrationTest.php
@@ -50,11 +50,10 @@ class DPLQueryIntegrationTest extends DPLIntegrationTestCase {
 			'namespace' => '',
 			'titlematch' => 'DPLTest%',
 			'notcategory' => 'DPLTestCategory',
-			'nottitle' => 'DPLTestOpenReferences'
 		] );
 
 		$this->assertArrayEquals(
-			[ 'DPLTestArticleNoCategory', 'DPLTestArticleOtherCategoryWithInfobox' ],
+			[ 'DPLTestArticleNoCategory', 'DPLTestArticleOtherCategoryWithInfobox', 'DPLTestOpenReferences' ],
 			$results,
 			true
 		);

--- a/tests/phpunit/DPLQueryIntegrationTest.php
+++ b/tests/phpunit/DPLQueryIntegrationTest.php
@@ -35,7 +35,7 @@ class DPLQueryIntegrationTest extends DPLIntegrationTestCase {
 			// NS_MAIN
 			'namespace' => '',
 			'notcategory' => 'DPLTestCategory',
-			'notcategory' => 'DPLTestCategory 2'
+			'nottitle' => 'DPLTestOpenReferences'
 		] );
 
 		$this->assertContains( 'DPLTestArticleNoCategory', $results );
@@ -50,7 +50,7 @@ class DPLQueryIntegrationTest extends DPLIntegrationTestCase {
 			'namespace' => '',
 			'titlematch' => 'DPLTest%',
 			'notcategory' => 'DPLTestCategory',
-			'notcategory' => 'DPLTestCategory 2'
+			'nottitle' => 'DPLTestOpenReferences'
 		] );
 
 		$this->assertArrayEquals(

--- a/tests/phpunit/DPLQueryIntegrationTest.php
+++ b/tests/phpunit/DPLQueryIntegrationTest.php
@@ -337,8 +337,9 @@ class DPLQueryIntegrationTest extends DPLIntegrationTestCase {
 		], $results );
 	}
 
-	public function testOpenReferences(): void {
+	public function testOpenReferencesMissing(): void {
 		$results = $this->getDPLQueryResults( [
+			// NS_MAIN
 			'namespace' => '',
 			'openreferences' => 'missing',
 			'count' => 1

--- a/tests/phpunit/DPLQueryIntegrationTest.php
+++ b/tests/phpunit/DPLQueryIntegrationTest.php
@@ -34,7 +34,8 @@ class DPLQueryIntegrationTest extends DPLIntegrationTestCase {
 		$results = $this->getDPLQueryResults( [
 			// NS_MAIN
 			'namespace' => '',
-			'notcategory' => 'DPLTestCategory'
+			'notcategory' => 'DPLTestCategory',
+			'notcategory' => 'DPLTestCategory 2'
 		] );
 
 		$this->assertContains( 'DPLTestArticleNoCategory', $results );
@@ -48,7 +49,8 @@ class DPLQueryIntegrationTest extends DPLIntegrationTestCase {
 			// NS_MAIN
 			'namespace' => '',
 			'titlematch' => 'DPLTest%',
-			'notcategory' => 'DPLTestCategory'
+			'notcategory' => 'DPLTestCategory',
+			'notcategory' => 'DPLTestCategory 2'
 		] );
 
 		$this->assertArrayEquals(

--- a/tests/seed-data.xml
+++ b/tests/seed-data.xml
@@ -280,7 +280,7 @@
 			<model>wikitext</model>
 			<format>text/x-wiki</format>
 			<text xml:space="preserve">[[DPLUncategorizedPage]][[RedLink]]
-[[Category:DPLTestCategory]]</text>
+[[Category:DPLTestCategory 2]]</text>
 			<sha1 />
 		</revision>
 	</page>

--- a/tests/seed-data.xml
+++ b/tests/seed-data.xml
@@ -279,7 +279,7 @@
 			<origin>29</origin>
 			<model>wikitext</model>
 			<format>text/x-wiki</format>
-			<text xml:space="preserve">[[DPLUncategorizedPage]][[RedLink]]</text>
+			<text xml:space="preserve">[[DPLTestArticle 1]][[DPLTestArticle 2]][[RedLink]][[DPLTestArticle 3]]</text>
 			<sha1 />
 		</revision>
 	</page>

--- a/tests/seed-data.xml
+++ b/tests/seed-data.xml
@@ -275,7 +275,7 @@
 				<username>DPLTestUser</username>
 				<id>2</id>
 			</contributor>
-			<comment>Create test page with redlinks</comment>
+			<comment>Create test page with red link</comment>
 			<origin>29</origin>
 			<model>wikitext</model>
 			<format>text/x-wiki</format>

--- a/tests/seed-data.xml
+++ b/tests/seed-data.xml
@@ -279,8 +279,7 @@
 			<origin>29</origin>
 			<model>wikitext</model>
 			<format>text/x-wiki</format>
-			<text xml:space="preserve">[[DPLUncategorizedPage]][[RedLink]]
-[[Category:DPLTestCategory 2]]</text>
+			<text xml:space="preserve">[[DPLUncategorizedPage]][[RedLink]]</text>
 			<sha1 />
 		</revision>
 	</page>

--- a/tests/seed-data.xml
+++ b/tests/seed-data.xml
@@ -264,4 +264,23 @@
 			<sha1 />
 		</revision>
 	</page>
+	<page>
+		<title>DPLTestOpenReferences</title>
+		<ns>0</ns>
+		<id>29</id>
+		<revision>
+			<id>29</id>
+			<timestamp>2021-09-04T04:00:00Z</timestamp>
+			<contributor>
+				<username>DPLTestUser</username>
+				<id>2</id>
+			</contributor>
+			<comment>Create test page with redlinks</comment>
+			<origin>29</origin>
+			<model>wikitext</model>
+			<format>text/x-wiki</format>
+			<text bytes="40" xml:space="preserve">[[DPLUncategorizedPage]][[RedLink]]</text>
+			<sha1 />
+		</revision>
+	</page>
 </mediawiki>

--- a/tests/seed-data.xml
+++ b/tests/seed-data.xml
@@ -279,7 +279,8 @@
 			<origin>29</origin>
 			<model>wikitext</model>
 			<format>text/x-wiki</format>
-			<text bytes="40" xml:space="preserve">[[DPLUncategorizedPage]][[RedLink]]</text>
+			<text xml:space="preserve">[[DPLUncategorizedPage]][[RedLink]]
+[[Category:DPLTestCategory]]</text>
 			<sha1 />
 		</revision>
 	</page>


### PR DESCRIPTION
* To fix #130

This converts `openreferences=missing` to initially query only missing articles from the `pagelinks` table. Previously it didn't query, just filtered output, which makes the `count` parameter still count all results, even ones not displayed on-page.