### PR TITLE
Fix profiling context calculation

### DIFF
--- a/includes/Parse.php
+++ b/includes/Parse.php
@@ -202,7 +202,13 @@ class Parse {
 			$query = new Query( $this->parameters );
 
 			$foundRows = null;
-			$rows = $query->buildAndSelect( $calcRows, $foundRows );
+			$profilingContext = '';
+			$currentTitle= $parser->getTitle();
+			if ( $currentTitle instanceof Title ) {
+				$profilingContext
+					= str_replace( [ '*', '/' ], '-', $currentTitle->getPrefixedDBkey() );
+			}
+			$rows = $query->buildAndSelect( $calcRows, $foundRows, $profilingContext );
 			if ( $rows === false ) {
 				// This error path is very fast (We exit immediately if poolcounter is full)
 				// Thus it should be safe to try again in ~5 minutes.

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -167,9 +167,10 @@ class Query {
 	 *
 	 * @param bool $calcRows
 	 * @param ?int &$foundRows
+	 * @param string $profilingContext Used to see the origin of a query in the profiling
 	 * @return array|bool
 	 */
-	public function buildAndSelect( bool $calcRows = false, ?int &$foundRows = null ) {
+	public function buildAndSelect( bool $calcRows = false, ?int &$foundRows = null, $profilingContext = '' ) {
 		global $wgNonincludableNamespaces, $wgDebugDumpSql;
 
 		$options = [];
@@ -363,10 +364,10 @@ class Query {
 			$options['MAX_EXECUTION_TIME'] = $maxQueryTime;
 		}
 
-		$parser = MediaWikiServices::getInstance()->getParser();
-		$pageName = str_replace( [ '*', '/' ], '-', $parser->getTitle()->getPrefixedDBkey() );
-
-		$qname = __METHOD__ . ' - ' . $pageName;
+		$qname = __METHOD__;
+		if ( !empty( $profilingContext ) ) {
+			$qname .= ' - ' . $profilingContext;
+		}
 		$where = $this->where;
 		$join = $this->join;
 		$db = $this->dbr;


### PR DESCRIPTION
`ParserFactory::getParser` will create a completely new `Parser` instance.
Based on the context, this instance may have not set a `Title` object.
Thus accessing `Parser::getTitle` without checking for the return value
may break the code.

Issue: https://github.com/Universal-Omega/DynamicPageList3/issues/170