### PR TITLE
Fix for links migration: add JOIN on linktarget for notuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -806,4 +806,4 @@ Many thanks to GreenReaper on GitHub for reporting and finding issues with core 
 
 # Version 3.5.1
 * Added a fix for links migration: added a `JOIN` on `linktarget` for the `notuses` parameter
-* Added PHPUnit test for the `notuses` parameter
+* Added a PHPUnit test for the `notuses` parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -803,3 +803,6 @@ Many thanks to GreenReaper on GitHub for reporting and finding issues with core 
 * Replaced usage of deprecated `User::matchEditToken()`
 * Replaced usage of deprecated `Article::doDelete()`
 * Added `null` checks on `Parser::getPage()` and `ParserOutput` before using to avoid fatals
+
+# Version 3.5.1
+* Added a fix for links migration: added a `JOIN` on `linktarget` for the `notuses` parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -806,3 +806,4 @@ Many thanks to GreenReaper on GitHub for reporting and finding issues with core 
 
 # Version 3.5.1
 * Added a fix for links migration: added a `JOIN` on `linktarget` for the `notuses` parameter
+* Added PHPUnit test for the `notuses` parameter

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "DynamicPageList3",
-	"version": "3.5.0",
+	"version": "3.5.1",
 	"author": [
 		"'''Universal Omega'''",
 		"Alexia E. Smith",

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -2268,7 +2268,7 @@ class Query {
 	 */
 	private function _notuses( $option ) {
 		if ( count( $option ) > 0 ) {
-			$where = $this->tableNames['page'] . '.page_id NOT IN (SELECT ' . $this->tableNames['templatelinks'] . '.tl_from FROM ' . $this->tableNames['templatelinks'] . ' WHERE (';
+			$where = $this->tableNames['page'] . '.page_id NOT IN (SELECT ' . $this->tableNames['templatelinks'] . '.tl_from FROM ' . $this->tableNames['templatelinks'] . ' INNER JOIN ' . $this->tableNames['linktarget'] . ' ON ' . $this->tableNames['linktarget'] . '.lt_id = ' . $this->tableNames['templatelinks'] . '.tl_target_id WHERE (';
 			$ors = [];
 
 			$linksMigration = MediaWikiServices::getInstance()->getLinksMigration();

--- a/tests/phpunit/DPLQueryIntegrationTest.php
+++ b/tests/phpunit/DPLQueryIntegrationTest.php
@@ -104,6 +104,17 @@ class DPLQueryIntegrationTest extends DPLIntegrationTestCase {
 		);
 	}
 
+	public function testFindPagesInCategoryNotUsingTemplate(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticleMultipleCategories' ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestOtherCategory',
+				'notuses' => 'Template:DPLInfobox'
+			] ),
+			true
+		);
+	}
+
 	public function testFindPagesNotInCategoryUsingTemplate(): void {
 		$this->assertArrayEquals(
 			[ 'DPLTestArticle 1' ],


### PR DESCRIPTION
Also adds a PHPUnit tests for the `notuses` parameter.