### PR TITLE
Fix `usedby` query returns all templates

### DIFF
--- a/tests/seed-data.xml
+++ b/tests/seed-data.xml
@@ -45,6 +45,24 @@
 		</revision>
 	</page>
 	<page>
+		<title>Template:DPLInfobox2</title>
+		<ns>10</ns>
+		<id>13123123123</id>
+		<revision>
+			<id>11231231231233</id>
+			<timestamp>2017-09-07T10:45:24Z</timestamp>
+			<contributor>
+				<username>DPLTestSystemUser</username>
+			</contributor>
+			<comment>Test template</comment>
+			<origin>11231231231233</origin>
+			<model>wikitext</model>
+			<format>text/x-wiki</format>
+			<text xml:space="preserve" bytes="13">Test template</text>
+			<sha1 />
+		</revision>
+	</page>
+	<page>
 		<title>Category:DPLTestCategory</title>
 		<ns>14</ns>
 		<id>14</id>


### PR DESCRIPTION
`usedby` DPL param was returning all templates on a wiki instead of those used by a page.

`templatelinks` is a many-to-many link that links sources to their link targets. It's used in a query executed by `usedby`. Because was no condition that would link template targets with their link targets, all templates are returned instead. I'm adding a linking condition that does just that and fixes the issue.

While we're at it, lets rewrite the mechanism of joining results from using WHERE clauses (which are notorious from causing troubles for an SQL engine's optimizer) to use standard JOINs.

The new test data should also cover the surfaced issue.

Query before the fix:
```sql
SELECT DISTINCT tplsrc.page_title     AS `tpl_sel_title`,
                tplsrc.page_namespace AS `tpl_sel_ns`,
                `page`.page_namespace AS `page_namespace`,
                `page`.page_id        AS `page_id`,
                `page`.page_title     AS `page_title`
FROM `linktarget` `lt`,
     `page` `tplsrc`,
     `templatelinks` `tpl`,
     `page`
WHERE `page`.page_is_redirect = 0
  AND (`page`.page_namespace = lt.lt_namespace AND `page`.page_title = lt.lt_title AND tplsrc.page_id = tpl.tl_from AND
       (tpl.tl_from = {{page_id}}))
LIMIT 500
```

Query after the fix (Added `AND` to link `templatelinks` target ID with `linktarget` ID:
```sql
SELECT DISTINCT `page`.page_title     AS `tpl_sel_title`,
                `page`.page_namespace AS `tpl_sel_ns`,
                `page`.page_namespace AS `page_namespace`,
                `page`.page_id        AS `page_id`,
                `page`.page_title     AS `page_title`
FROM `page`
         JOIN `linktarget` `lt` ON ((page_title = lt_title) AND (page_namespace = lt_namespace))
         JOIN `templatelinks` `tpl` ON ((lt_id = tl_target_id))
WHERE `page`.page_is_redirect = 0
  AND ((tpl.tl_from = {{page_id}}))
LIMIT 500
```