### PR TITLE
Don't return the viewer's IP address as %USER% if rev_actor is 0.

### DIFF
--- a/includes/Article.php
+++ b/includes/Article.php
@@ -211,7 +211,7 @@ class Article {
 		$article = new self( $title, $pageNamespace );
 
 		$revActorName = ActorStore::UNKNOWN_USER_NAME;
-		if ( isset( $row->rev_actor ) ) {
+		if ( isset( $row->rev_actor ) && $row->rev_actor !== '0' ) {
 			$revActorName = $userFactory->newFromActorId( $row->rev_actor )->getName();
 		}
 


### PR DESCRIPTION
User->getName() falls back to the current user's IP address if there is no user name.