### PR TITLE
Fix minoredits=exclude

### DIFF
--- a/includes/Query.php
+++ b/includes/Query.php
@@ -1576,18 +1576,6 @@ class Query {
 	}
 
 	/**
-	 * Set SQL for 'minoredits' parameter.
-	 *
-	 * @param mixed $option
-	 */
-	private function _minoredits( $option ) {
-		if ( isset( $option ) && $option == 'exclude' ) {
-			$this->addTable( 'revision', 'revision' );
-			$this->addWhere( 'revision.rev_minor_edit = 0' );
-		}
-	}
-
-	/**
 	 * Set SQL for 'minrevisions' parameter.
 	 *
 	 * @param mixed $option
@@ -1867,12 +1855,13 @@ class Query {
 						$this->addSelect( [ 'rev.rev_timestamp' ] );
 
 						if ( !$this->revisionAuxWhereAdded ) {
-							$this->addWhere(
-								[
-									"{$this->tableNames['page']}.page_id = rev.rev_page",
-									"rev.rev_timestamp = (SELECT MAX(rev_aux.rev_timestamp) FROM {$this->tableNames['revision']} AS rev_aux WHERE rev_aux.rev_page = rev.rev_page)"
-								]
-							);
+							$this->addWhere( "{$this->tableNames['page']}.page_id = rev.rev_page" );
+
+							if ( $this->parameters->getParameter( 'minoredits' ) == 'exclude' ) {
+								$this->addWhere( "rev.rev_timestamp = (SELECT MAX(rev_aux.rev_timestamp) FROM {$this->tableNames['revision']} AS rev_aux WHERE rev_aux.rev_page = rev.rev_page AND rev_aux.rev_minor_edit = 0)" );
+							} else {
+								$this->addWhere( "rev.rev_timestamp = (SELECT MAX(rev_aux.rev_timestamp) FROM {$this->tableNames['revision']} AS rev_aux WHERE rev_aux.rev_page = rev.rev_page)" );
+							}
 						}
 
 						$this->revisionAuxWhereAdded = true;


### PR DESCRIPTION
fixes issue #226

Previously, the query selected the latest revision for each page based on the rev_timestamp, but did not consider the rev_minor_edit value.
Now it will retrieve the latest revision that satisfies the condition rev.rev_minor_edit = 0.