### PR TITLE
Fix "PHP Deprecated: trim(): Passing null to parameter #1 ($string) o…

### DIFF
--- a/includes/Parse.php
+++ b/includes/Parse.php
@@ -886,10 +886,10 @@ class Parse {
 		$scrollVariables = (array)$scrollVariables;
 
 		foreach ( $scrollVariables as $variable => $value ) {
-			Variables::setVar( [ '', '', $variable, $value ] );
+			Variables::setVar( [ '', '', $variable, $value ?? '' ] );
 
 			if ( defined( 'ExtVariables::VERSION' ) ) {
-				ExtVariables::get( $parser )->setVarValue( $variable, $value );
+				ExtVariables::get( $parser )->setVarValue( $variable, $value ?? '' );
 			}
 		}
 	}


### PR DESCRIPTION
…f type string is deprecated"