### PR TITLE
Fix `PHP Warning: Trying to access array offset on value of type null`

### DIFF
--- a/includes/Parameters.php
+++ b/includes/Parameters.php
@@ -957,7 +957,7 @@ class Parameters extends ParametersData {
 	public function _nottitleregexp( $option ) {
 		$data = $this->getParameter( 'nottitle' );
 
-		if ( !is_array( $data['regexp'] ) ) {
+		if ( !$data || !is_array( $data['regexp'] ) ) {
 			$data['regexp'] = [];
 		}
 


### PR DESCRIPTION
Quick fix for `nottitleregexp` parameter that logs the following warning on use:
```
PHP Warning: Trying to access array offset on value of type null in /extensions/DynamicPageList/includes/Parameters.php on line 960
```