### PR TITLE
Adapted queries to the new pagelinks table schema [MW 1.43]

### DIFF
--- a/includes/Parse.php
+++ b/includes/Parse.php
@@ -391,8 +391,8 @@ class Parse {
 					$pageTitle = $row->il_to;
 				} else {
 					// Maybe non-existing title
-					$pageNamespace = $row->pl_namespace;
-					$pageTitle = $row->pl_title;
+					$pageNamespace = $row->lt_namespace;
+					$pageTitle = $row->lt_title;
 				}
 			} else {
 				// Existing PAGE TITLE

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -1352,12 +1352,15 @@ class Query {
 			$this->addTable( 'pagelinks', 'plf' );
 			$this->addTable( 'linktarget', 'lt' );
 			$this->addTable( 'page', 'pagesrc' );
-			$this->addSelect(
-				[
-					'sel_title' => 'pagesrc.page_title',
-					'sel_ns' => 'pagesrc.page_namespace'
-				]
-			);
+
+			if ( $this->isPageselFormatUsed() ) {
+				$this->addSelect(
+					[
+						'sel_title' => 'pagesrc.page_title',
+						'sel_ns' => 'pagesrc.page_namespace'
+					]
+				);
+			}
 
 			$where = [
 				$this->tableNames['page'] . '.page_namespace = lt.lt_namespace',
@@ -1388,7 +1391,11 @@ class Query {
 		if ( count( $option ) > 0 ) {
 			$this->addTable( 'pagelinks', 'pl' );
 			$this->addTable( 'linktarget', 'lt' );
-			$this->addSelect( [ 'sel_title' => 'lt.lt_title', 'sel_ns' => 'lt.lt_namespace' ] );
+
+			if ( $this->isPageselFormatUsed() ) {
+				$this->addSelect( [ 'sel_title' => 'lt.lt_title', 'sel_ns' => 'lt.lt_namespace' ] );
+			}
+
 			$this->addWhere( 'pl.pl_target_id = lt.lt_id' );
 
 			foreach ( $option as $index => $linkGroup ) {
@@ -2274,5 +2281,15 @@ class Query {
 		}
 
 		$this->addWhere( $where ?? '' );
+	}
+
+	private function isPageselFormatUsed(): bool {
+		if ( $this->parameters->getParameter( 'listseparators' ) ) {
+			$format = implode( ',', $this->parameters->getParameter( 'listseparators' ) );
+			if ( strstr( $format, '%PAGESEL%' ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -1269,6 +1269,10 @@ class Query {
 	private function _imageused( $option ) {
 		$where = [];
 
+		if ( $this->parameters->getParameter( 'distinct' ) == 'strict' ) {
+			$this->addGroupBy( 'page_title' );
+		}
+
 		$this->addTable( 'imagelinks', 'il' );
 		$this->addSelect(
 			[

--- a/tests/phpunit/DPLQueryIntegrationTest.php
+++ b/tests/phpunit/DPLQueryIntegrationTest.php
@@ -466,6 +466,23 @@ class DPLQueryIntegrationTest extends DPLIntegrationTestCase {
 		);
 	}
 
+	public function testFindPagesLinkedFromPageWithPagesel(): void {
+		$results = $this->getDPLQueryResults( [
+			// NS_MAIN
+			'namespace' => '',
+			'linksfrom' => 'DPLTestArticle 1',
+		], '%PAGESEL% to %PAGE%' );
+
+		$this->assertArrayEquals(
+			[
+				'DPLTestArticle 1 to DPLTestArticle 2',
+				'DPLTestArticle 1 to DPLTestArticleNoCategory',
+			],
+			$results,
+			true
+		);
+	}
+
 	public function testFindPagesLinkedFromPageOrderedByPagesel(): void {
 		$results = $this->getDPLQueryResults( [
 			// NS_MAIN
@@ -478,7 +495,6 @@ class DPLQueryIntegrationTest extends DPLIntegrationTestCase {
 			[
 				'DPLTestArticleNoCategory',
 				'DPLTestArticle 1',
-				'DPLTestArticle 2',
 				'DPLTestArticle 2',
 				'DPLTestArticle 3',
 			],

--- a/tests/phpunit/DPLQueryIntegrationTest.php
+++ b/tests/phpunit/DPLQueryIntegrationTest.php
@@ -318,6 +318,42 @@ class DPLQueryIntegrationTest extends DPLIntegrationTestCase {
 		);
 	}
 
+	public function testFindPagesInCategoryOrderedByTitleWithoutNamespace(): void {
+		$results = $this->getDPLQueryResults( [
+			'category' => 'DPLTestCategory',
+			'ordermethod' => 'titlewithoutnamespace',
+		] );
+
+		$this->assertArrayEquals(
+			[
+				'DPLTestArticleMultipleCategories',
+				'DPLTestArticle 1',
+				'DPLTestArticle 2',
+				'DPLTestArticle 3',
+			],
+			$results,
+			true
+		);
+	}
+
+	public function testFindPagesInCategoryOrderedByFullTitle(): void {
+		$results = $this->getDPLQueryResults( [
+			'category' => 'DPLTestCategory',
+			'ordermethod' => 'title',
+		] );
+
+		$this->assertArrayEquals(
+			[
+				'DPLTestArticle 1',
+				'DPLTestArticle 2',
+				'DPLTestArticle 3',
+				'DPLTestArticleMultipleCategories',
+			],
+			$results,
+			true
+		);
+	}
+
 	public function testGetPageAuthors(): void {
 		$results = $this->getDPLQueryResults( [
 			'category' => 'DPLTestCategory',
@@ -372,6 +408,122 @@ class DPLQueryIntegrationTest extends DPLIntegrationTestCase {
 			],
 			$results,
 			true
+		);
+	}
+
+	public function testFindPagesLinkingToPage(): void {
+		$results = $this->getDPLQueryResults( [
+			// NS_MAIN
+			'namespace' => '',
+			'linksto' => 'DPLTestArticle 2',
+		] );
+
+		$this->assertArrayEquals(
+			[
+				'DPLTestArticle 1',
+				'DPLTestOpenReferences',
+			],
+			$results,
+			true
+		);
+	}
+
+	public function testFindPagesNotLinkingToPage(): void {
+		$results = $this->getDPLQueryResults( [
+			// NS_MAIN
+			'namespace' => '',
+			'notlinksto' => 'DPLTestArticle 2',
+		] );
+
+		$this->assertArrayEquals(
+			[
+				'DPLTestArticle 2',
+				'DPLTestArticle 3',
+				'DPLTestArticleNoCategory',
+				'DPLTestArticleMultipleCategories',
+				'DPLTestArticleOtherCategoryWithInfobox',
+				'DPLUncategorizedPage',
+			],
+			$results,
+			true
+		);
+	}
+
+	public function testFindPagesLinkedFromPage(): void {
+		$results = $this->getDPLQueryResults( [
+			// NS_MAIN
+			'namespace' => '',
+			'linksfrom' => 'DPLTestArticle 1',
+		] );
+
+		$this->assertArrayEquals(
+			[
+				'DPLTestArticle 2',
+				'DPLTestArticleNoCategory',
+			],
+			$results,
+			true
+		);
+	}
+
+	public function testFindPagesLinkedFromPageOrderedByPagesel(): void {
+		$results = $this->getDPLQueryResults( [
+			// NS_MAIN
+			'namespace' => '',
+			'linksfrom' => 'DPLTestOpenReferences|DPLTestArticle 1',
+			'ordermethod' => 'pagesel',
+		] );
+
+		$this->assertArrayEquals(
+			[
+				'DPLTestArticleNoCategory',
+				'DPLTestArticle 1',
+				'DPLTestArticle 2',
+				'DPLTestArticle 2',
+				'DPLTestArticle 3',
+			],
+			$results,
+			true
+		);
+	}
+
+	public function testFindPagesNotLinkedFromPage(): void {
+		$results = $this->getDPLQueryResults( [
+			// NS_MAIN
+			'namespace' => '',
+			'notlinksfrom' => 'DPLTestArticle 1',
+		] );
+
+		$this->assertArrayEquals(
+			[
+				'DPLTestArticle 1',
+				'DPLTestArticle 3',
+				'DPLTestArticleMultipleCategories',
+				'DPLTestArticleOtherCategoryWithInfobox',
+				'DPLUncategorizedPage',
+				'DPLTestOpenReferences',
+			],
+			$results,
+			true
+		);
+	}
+
+	public function testFindPagesWithOpenReferencesLinkedFromPage(): void {
+		$results = $this->getDPLQueryResults( [
+			// NS_MAIN
+			'namespace' => '',
+			'linksfrom' => 'DPLTestOpenReferences',
+			'openreferences' => 'yes',
+		] );
+
+		$this->assertArrayEquals(
+			[
+				'DPLTestArticle 1',
+				'DPLTestArticle 2',
+				'DPLTestArticle 3',
+				'RedLink',
+			],
+			$results
 		);
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Universal-Omega/DynamicPageList3/issues/292

Due to changes in the `pagelinks` table schema, we have to join with the `linktarget` table. This PR fixes `linksto`, `linksfrom`, `notlinksto`, `notlinksfrom` and `ordermethod` for MW 1.43. It also fixes `openreferences` support for `title`, `notitle`, `namespace`, `notnamespace`, `titlelt` and `titlegt`.

See https://www.mediawiki.org/wiki/Manual:Pagelinks_table

I added test cases to cover more parameters.

## Caveat

There is one edge case that this code doesn't support anymore: `distinct=strict`. Actually, due to a bug (loose typing), the "strict" mode was always used (because in PHP, `true == 'strict'`).

The only case where it matters is when we use `linksfrom=Page1|Page2` and both pages link to, let's say, Page3. We don't want Page3 to be duplicated in a list, so there was a `DISTINCT` clause combined with `GROUP BY`. However, there can be a duplicate when we use `%PAGESEL%` in the output format.

The `GROUP BY` deduplication trick didn't work anymore because MySQL returned an error that says `'wikidb.lt.lt_title' isn't in GROUP BY`. This happens because in `linktarget`, the namespace and the title aren't parts of the primary key (unlike the old `pagelinks` table). If MySQL has two rows in the same group, it doesn't know which one to pick.

I decided to include `sel_ns` and `sel_title` in the query only if there's `%PAGESEL%` used in the user format. This way, deduplication is done by the `DISTINCT` clause and we don't need `GROUP BY` tricks.