### PR TITLE
Restore partial support for `linkstoexternal` and introduce replacement via `linkstoexternaldomain` and `linkstoexternalpath`

### DIFF
--- a/includes/ExternalDomainPatternParser.php
+++ b/includes/ExternalDomainPatternParser.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace MediaWiki\Extension\DynamicPageList3;
+
+use MediaWiki\Extension\DynamicPageList3\Tests\DPLExternalDomainPatternParserTest;
+
+trait ExternalDomainPatternParser {
+	/**
+	 * We provide:
+	 * * full support for "standalone" wildcard usage (eg. `%.fandom.com`)
+	 * * partial support for wildcard usage when it is not separated by `.` (eg. `%fandom.com would match starwars.fandom-suffix.com)
+	 * * protocols followed by the `://` are supported, like `http://` or `https://` (`mailto:` on the other hand is not supported)
+	 *
+	 * @See DPLExternalDomainPatternParserTest for example cases
+	 */
+	private function parseDomainPattern( string $pattern ): string {
+		$protocol = false;
+		// Protocol is specified. Strip it
+		if ( str_contains( $pattern, '://' ) ) {
+			[$protocol, $pattern] = explode( '://', $pattern );
+		}
+
+		// Previous step will strip protocol if it was specified
+		[$domainPattern, ] = explode( '/', $pattern, 2 );
+		$parts = explode( '.', $domainPattern );
+		$reversed = array_reverse( $parts );
+		foreach ( $reversed as &$part ) {
+			if ( $part === '%' ) {
+				continue;
+			}
+			if ( str_starts_with( $part, '%' ) ) {
+				$part .= '%';
+			} else if ( str_ends_with( $part, '%' ) ) {
+				$part = '%' . $part;
+			}
+		}
+
+		$rawPattern = implode( '.', $reversed );
+		if ( $protocol ) {
+			return "$protocol://$rawPattern.";
+		}
+		return "%://$rawPattern.";
+	}
+}

--- a/includes/ExternalDomainPatternParser.php
+++ b/includes/ExternalDomainPatternParser.php
@@ -8,8 +8,10 @@ trait ExternalDomainPatternParser {
 	/**
 	 * We provide:
 	 * * full support for "standalone" wildcard usage (eg. `%.fandom.com`)
-	 * * partial support for wildcard usage when it is not separated by `.` (eg. `%fandom.com would match starwars.fandom-suffix.com)
-	 * * protocols followed by the `://` are supported, like `http://` or `https://` (`mailto:` on the other hand is not supported)
+	 * * partial support for wildcard usage when it is not separated by `.`
+	 *   (eg. `%fandom.com would match starwars.fandom-suffix.com)
+	 * * protocols followed by the `://` are supported, like `http://` or `https://`
+	 *   (`mailto:` on the other hand is not supported)
 	 *
 	 * @See DPLExternalDomainPatternParserTest for example cases
 	 */

--- a/includes/ParametersData.php
+++ b/includes/ParametersData.php
@@ -133,6 +133,9 @@ class ParametersData {
 			'categoryregexp',
 			'firstrevisionsince',
 			'lastrevisionbefore',
+			'linkstoexternal',
+			'linkstoexternaldomain',
+			'linkstoexternalpath',
 			'maxrevisions',
 			'minrevisions',
 			'notcategorymatch',
@@ -149,7 +152,6 @@ class ParametersData {
 		],
 		// Should never be used; likely broken or will cause exceptions
 		5 => [
-			'linkstoexternal',
 		],
 	];
 
@@ -578,12 +580,36 @@ class ParametersData {
 			'set_criteria_found' => true
 		],
 		/**
-		 * This parameter restricts the output to articles which contain an external
-		 * reference that conatins a certain pattern.
-		 *
-		 * Examples:   linkstoexternal= www.xyz.com|www.xyz2.com
+		 * Alias for `linkstoexternaldomain`.
+		 * To mimic old behaviour use `linkstoexternaldomain` together with `linkstoexternalpath`
 		 */
 		'linkstoexternal' => [
+			'default' => null,
+			'open_ref_conflict' => true,
+			'page_name_list' => true,
+			'page_name_must_exist' => false,
+			'set_criteria_found' => true
+		],
+		/**
+		 * This parameter restricts the output to articles which contain an external
+		 * domain reference that contains a certain pattern.
+		 *
+		 * Examples:   linkstoexternaldomain=www.xyz.com|www.xyz2.%
+		 */
+		'linkstoexternaldomain' => [
+			'default' => null,
+			'open_ref_conflict' => true,
+			'page_name_list' => true,
+			'page_name_must_exist' => false,
+			'set_criteria_found' => true
+		],
+		/**
+		 * This parameter restricts the output to articles which contain an external
+		 * path reference that contains a certain pattern.
+		 *
+		 * Examples:   linkstoexternalpath=/xyz/%|%/abc/%
+		 */
+		'linkstoexternalpath' => [
 			'default' => null,
 			'open_ref_conflict' => true,
 			'page_name_list' => true,

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -1621,15 +1621,17 @@ class Query {
 					$domainPatterns
 				);
 
-				$where = "{$this->tableNames['page']}.page_id=el.el_from AND ({$this->dbr->makeList( $ors, ISQLPlatform::LIST_OR )})";
+				$where = "{$this->tableNames['page']}.page_id=el.el_from " .
+					" AND ({$this->dbr->makeList( $ors, ISQLPlatform::LIST_OR )})";
 			} else {
+				$linksTable = $this->tableNames['externallinks'];
 				$ors = array_map(
-					fn ( $pattern ) => "{$this->tableNames['externallinks']}.el_to_domain_index LIKE {$this->dbr->addQuotes( $pattern )}",
+					fn ( $pattern ) => "$linksTable.el_to_domain_index LIKE {$this->dbr->addQuotes( $pattern )}",
 					$domainPatterns
 				);
 
-				$where = "EXISTS(SELECT el_from FROM {$this->tableNames['externallinks']} " .
-					" WHERE ({$this->tableNames['externallinks']}.el_from=page_id " .
+				$where = "EXISTS(SELECT el_from FROM $linksTable " .
+					" WHERE ($linksTable.el_from=page_id " .
 					" AND ({$this->dbr->makeList( $ors, ISQLPlatform::LIST_OR )})))";
 			}
 
@@ -1662,15 +1664,17 @@ class Query {
 					$paths
 				);
 
-				$where = "{$this->tableNames['page']}.page_id=el.el_from AND ({$this->dbr->makeList( $ors, ISQLPlatform::LIST_OR )})";
+				$where = "{$this->tableNames['page']}.page_id=el.el_from " .
+					" AND ({$this->dbr->makeList( $ors, ISQLPlatform::LIST_OR )})";
 			} else {
+				$linksTable = $this->tableNames['externallinks'];
 				$ors = array_map(
-					fn ( $path ) => "{$this->tableNames['externallinks']}.el_to_path LIKE {$this->dbr->addQuotes( $path )}",
+					fn ( $path ) => "$linksTable.el_to_path LIKE {$this->dbr->addQuotes( $path )}",
 					$paths
 				);
 
-				$where = "EXISTS(SELECT el_from FROM {$this->tableNames['externallinks']} " .
-					" WHERE ({$this->tableNames['externallinks']}.el_from=page_id " .
+				$where = "EXISTS(SELECT el_from FROM $linksTable " .
+					" WHERE ($linksTable.el_from=page_id " .
 					" AND ({$this->dbr->makeList( $ors, ISQLPlatform::LIST_OR )})))";
 			}
 

--- a/tests/phpunit/DPLExternalDomainPatternParserTest.php
+++ b/tests/phpunit/DPLExternalDomainPatternParserTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace MediaWiki\Extension\DynamicPageList3\Tests;
+use MediaWiki\Extension\DynamicPageList3\ExternalDomainPatternParser;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group DynamicPageList3
+ */
+class DPLExternalDomainPatternParserTest extends TestCase {
+	use ExternalDomainPatternParser;
+
+	#[DataProvider( 'getDomainPattern' )]
+	public function testParseDomainPattern( string $domain, string $expected ): void {
+		$actual = $this->parseDomainPattern( $domain );
+		$this->assertSame( $expected, $actual );
+	}
+
+	public static function getDomainPattern(): array {
+		return [
+			// Full domain with extra path and without any wildcards
+			[ 'http://www.fandom.com/test123/test?test=%', 'http://com.fandom.www.' ],
+			// Protocol is preserved if specified (only protocols separated by `://` are supported)
+			[ 'irc://starwars.%/test123/test', 'irc://%.starwars.' ],
+			[ 'https://starwars.%/test123/test', 'https://%.starwars.' ],
+			// Domain with `%` at the end
+			[ 'http://starwars.%/test123/test?test=%', 'http://%.starwars.' ],
+			// Domain with `%` at the begging. We have to guess the protocol
+			[ '%.fandom.com/test123/test?test=%', '%://com.fandom.%.' ],
+			// Domain with wildcard at the begging without separation
+			[ '%fandom.com/test123/test?test=%', '%://com.%fandom%.' ],
+			// Domain with wildcard in the middle, separated by `.`
+			[ 'www.%.com/test123/test?test=%', '%://com.%.www.' ],
+			// Domain with wildcard at the begging separated by `.` from one side
+			[ 'www.%fandom.com', '%://com.%fandom%.www.' ],
+			// Domain with wildcard at the begging separated by `.` from the other side
+			[ 'www.fandom%.com', '%://com.%fandom%.www.' ],
+			// Duplicated wildcard doesn't matter
+			[ 'www.%%fandom.com', '%://com.%%fandom%.www.' ],
+		];
+	}
+
+	/**
+	 * This test documents cases that are not correctly supported
+	 */
+	#[DataProvider( 'getUnsupportedDomainPattern' )]
+	public function testUnsupportedDomainPatterns( string $domain, string $expected ): void {
+		$actual = $this->parseDomainPattern( $domain );
+		$this->assertSame( $expected, $actual );
+	}
+
+	public static function getUnsupportedDomainPattern(): array {
+		return [
+			// We are not supporting `_` as a `.`
+			[ 'http://www.fandom_com', 'http://fandom_com.www.' ],
+			// Domain with wildcard in the middle not followed by `.` is not processed
+			[ 'ww%fandom.com', '%://com.ww%fandom.' ],
+			[ '%www%fandom.com', '%://com.%www%fandom%.' ],
+			// When wildcard should cover `/` we would generate garbage
+			[ '%fandom.%?test=%', '%://%?test=%%.%fandom%.' ],
+		];
+	}
+}

--- a/tests/phpunit/DPLExternalDomainPatternParserTest.php
+++ b/tests/phpunit/DPLExternalDomainPatternParserTest.php
@@ -11,6 +11,10 @@ use PHPUnit\Framework\TestCase;
 class DPLExternalDomainPatternParserTest extends TestCase {
 	use ExternalDomainPatternParser;
 
+	/**
+	 * This test documents cases which are correctly supported
+	 * @covers ExternalDomainPatternParser
+	 */
 	#[DataProvider( 'getDomainPattern' )]
 	public function testParseDomainPattern( string $domain, string $expected ): void {
 		$actual = $this->parseDomainPattern( $domain );
@@ -42,7 +46,8 @@ class DPLExternalDomainPatternParserTest extends TestCase {
 	}
 
 	/**
-	 * This test documents cases that are not correctly supported
+	 * This test documents cases that are NOT correctly supported
+	 * @covers ExternalDomainPatternParser
 	 */
 	#[DataProvider( 'getUnsupportedDomainPattern' )]
 	public function testUnsupportedDomainPatterns( string $domain, string $expected ): void {


### PR DESCRIPTION
Related issue: https://github.com/Universal-Omega/DynamicPageList3/issues/274