### PR TITLE
Fix type mismatch between what is returned by `getLinkList` (list of arrays that contains non-serializable TitleValue) and what is expected by ParserOutput.

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -6,7 +6,6 @@ use MediaWiki\Extension\DynamicPageList3\Maintenance\CreateTemplate;
 use MediaWiki\Extension\DynamicPageList3\Maintenance\CreateView;
 use MediaWiki\Installer\DatabaseUpdater;
 use MediaWiki\Parser\Parser;
-use MediaWiki\Parser\ParserOutputLinkTypes;
 use MediaWiki\Parser\PPFrame;
 use MediaWiki\Registration\ExtensionRegistry;
 
@@ -219,7 +218,7 @@ class Hooks {
 
 		// we can remove the templates by save/restore
 		if ( $reset['templates'] ?? false ) {
-			$saveTemplates = $parserOutput->getLinkList( ParserOutputLinkTypes::TEMPLATE );
+			$saveTemplates = $parserOutput->mTemplates;
 		}
 
 		// we can remove the categories by save/restore
@@ -235,7 +234,7 @@ class Hooks {
 
 		// we can remove the images by save/restore
 		if ( $reset['images'] ?? false ) {
-			$saveImages = $parserOutput->getLinkList( ParserOutputLinkTypes::MEDIA );
+			$saveImages = $parserOutput->mImages;
 		}
 
 		$parsedDPL = $parser->recursiveTagParse( $text );
@@ -622,7 +621,7 @@ class Hooks {
 		// called during the final output phase; removes links created by DPL
 		if ( self::$createdLinks ) {
 			if ( array_key_exists( 0, self::$createdLinks ) ) {
-				$parserLinks = $parser->getOutput()->getLinkList( ParserOutputLinkTypes::LOCAL );
+				$parserLinks = $parser->getOutput()->mLinks;
 				foreach ( $parserLinks as $nsp => $link ) {
 					if ( !array_key_exists( $nsp, self::$createdLinks[0] ) ) {
 						continue;
@@ -640,7 +639,7 @@ class Hooks {
 			}
 
 			if ( array_key_exists( 1, self::$createdLinks ) ) {
-				$parserTemplates = $parser->getOutput()->getLinkList( ParserOutputLinkTypes::TEMPLATE );
+				$parserTemplates = $parser->getOutput()->mTemplates;
 				foreach ( $parserTemplates as $nsp => $tpl ) {
 					if ( !array_key_exists( $nsp, self::$createdLinks[1] ) ) {
 						continue;
@@ -670,8 +669,8 @@ class Hooks {
 			}
 
 			if ( array_key_exists( 3, self::$createdLinks ) ) {
-				$parserMedia = $parser->getOutput()->getLinkList( ParserOutputLinkTypes::MEDIA );
-				$parser->getOutput()->mImages = array_diff_assoc( $parserMedia, self::$createdLinks[3] );
+				$parser->getOutput()->mImages = array_diff_assoc(
+					$parser->getOutput()->mImages, self::$createdLinks[3] );
 			}
 		}
 	}

--- a/includes/Parse.php
+++ b/includes/Parse.php
@@ -9,7 +9,6 @@ use MediaWiki\Extension\DynamicPageList3\Heading\Heading;
 use MediaWiki\Extension\DynamicPageList3\Lister\Lister;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Parser\Parser;
-use MediaWiki\Parser\ParserOutputLinkTypes;
 use MediaWiki\Registration\ExtensionRegistry;
 use MediaWiki\Request\WebRequest;
 use MediaWiki\Title\Title;
@@ -1105,7 +1104,7 @@ class Parse {
 				// statement itself uses one of these links they will be thrown away!
 				Hooks::$createdLinks[0] = [];
 
-				foreach ( $parserOutput->getLinkList( ParserOutputLinkTypes::LOCAL ) as $nsp => $link ) {
+				foreach ( $parserOutput->mLinks as $nsp => $link ) {
 					Hooks::$createdLinks[0][$nsp] = $link;
 				}
 			}
@@ -1113,7 +1112,7 @@ class Parse {
 			if ( $parserOutput && isset( $eliminate['templates'] ) && $eliminate['templates'] ) {
 				Hooks::$createdLinks[1] = [];
 
-				foreach ( $parserOutput->getLinkList( ParserOutputLinkTypes::TEMPLATE ) as $nsp => $tpl ) {
+				foreach ( $parserOutput->mTemplates as $nsp => $tpl ) {
 					Hooks::$createdLinks[1][$nsp] = $tpl;
 				}
 			}


### PR DESCRIPTION
The new version of DPL is causing MediaWiki to log `Unable to serialize JSON` exceptions on some of the pages when `ParserCache` is trying to serialize `ParserOutput` to JSON.

This is caused by the fact that the new [getLinkList](https://github.com/Wikia/mediawiki/blob/REL1_43/includes/parser/ParserOutput.php#L787) is not a 1:1 replacement for various deprecated getters in `ParserOutput`, as it returns a different type of data. And we shouldn't assign that to the internal fields of `ParserOutput`. 

For now, I have replaced it with direct field access, as I currently see no other viable solution to resolve this issue.