### PR TITLE
Show raw query exception if the request is not made

### DIFF
--- a/includes/Query.php
+++ b/includes/Query.php
@@ -365,8 +365,12 @@ class Query {
 				$this->sqlQuery = $query;
 			}
 		} catch ( Exception $e ) {
+			$errorMessage = $this->dbr->lastError();
+			if ( $errorMessage == '' ) {
+				$errorMessage = strval( $e );
+			}
 			throw new LogicException( __METHOD__ . ': ' . wfMessage(
-				'dpl_query_error', Hooks::getVersion(), $this->dbr->lastError()
+				'dpl_query_error', Hooks::getVersion(), $errorMessage
 			)->text() );
 		}
 


### PR DESCRIPTION
After upgrading to MW 1.44, I have been getting errors like:
```
Extension:DynamicPageList3 (DPL3), version 3.6.2: Error: MediaWiki\Extension\DynamicPageList3\Query::buildAndSelect: The DynamicPageList3 extension (version 3.6.2) produced a SQL statement which led to a Database error.<br/>The reason may be an internal error of DynamicPageList3 or an error that you made; especially when using parameters like 'categoryregexp' or 'titleregexp'. Usage of non-greedy <code>*?</code> matching patterns are not supported.<br/>The error message was:<br/><code></code>
```

The real exception is:
```
Wikimedia\Rdbms\DBLanguageError: Identifier must not contain quote, dot or null characters: got '`page`' in /opt/mediawiki/includes/libs/rdbms/platform/SQLPlatform.php:88 Stack trace:
    0 /opt/mediawiki/includes/libs/rdbms/platform/SQLPlatform.php(1033): Wikimedia\Rdbms\Platform\SQLPlatform->addIdentifierQuotes('`page`')
```

The request was not sent to the DB at all, so `lastError` is empty. In this case, the exception should be shown.