### PR TITLE
Pass unquoted table name to RDBMS

### DIFF
--- a/includes/Query.php
+++ b/includes/Query.php
@@ -200,7 +200,7 @@ class Query {
 
 		if ( !$this->parameters->getParameter( 'openreferences' ) ) {
 			// Add things that are always part of the query.
-			$this->addTable( 'page', $this->tableNames['page'] );
+			$this->addTable( 'page', 'page' );
 			$this->addSelect(
 				[
 					'page_namespace' => $this->tableNames['page'] . '.page_namespace',
@@ -487,7 +487,7 @@ class Query {
 		}
 
 		if ( !isset( $this->tables[$alias] ) ) {
-			$this->tables[$alias] = $this->dbr->tableName( $table );
+			$this->tables[$alias] = $table;
 
 			return true;
 		} else {


### PR DESCRIPTION
Since f3607d6512cd (Simplify addIdentifierQuotes and its inverse, 2023-12-13),
IDatabase::selectSQLText expects the table array to contain
unquoted table names, or an error will be thrown:

Wikimedia\Rdbms\DBLanguageError: Identifier must not contain quote,
dot or null characters: got '`page`'
in mediawiki/includes/libs/rdbms/platform/SQLPlatform.php:88