### PR TITLE
Fix PHP warning in Parameters::_nottitleregexp (uninitialised array/key)

### DIFF
--- a/includes/Parameters.php
+++ b/includes/Parameters.php
@@ -991,7 +991,7 @@ class Parameters extends ParametersData {
 	public function _nottitleregexp( $option ) {
 		$data = $this->getParameter( 'nottitle' );
 
-		if ( !is_array( $data['regexp'] ) ) {
+		if ( !is_array( $data['regexp'] ?? null ) ) {
 			$data['regexp'] = [];
 		}
 


### PR DESCRIPTION
`Parameters::getParameter('nottitle')` returns a null when `_nottitleregexp` is first invoked - which means the `'regexp'` key check results in an attempt to index null. This results in a PHP warning.

Coalescing the access should be sufficient here given auto-vivification from `null` is not deprecated.