### PR TITLE
Fix openreferences

### DIFF
--- a/includes/Parse.php
+++ b/includes/Parse.php
@@ -899,8 +899,10 @@ class Parse {
 
 		// The 'openreferences' parameter is incompatible with many other options.
 		if (
-			$this->parameters->isOpenReferencesConflict() &&
-			$this->parameters->getParameter( 'openreferences' ) === true
+			$this->parameters->isOpenReferencesConflict() && (
+			$this->parameters->getParameter( 'openreferences' ) === true ||
+				$this->parameters->getParameter( 'openreferences' ) === 'missing'
+			)
 		) {
 			$this->logger->addMessage( Hooks::FATAL_OPENREFERENCES );
 			return false;

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -117,7 +117,7 @@ class Query {
 			} else {
 				$this->queryBuilder->table( 'pagelinks', 'pl' );
 				$this->queryBuilder->join( 'linktarget', 'lt', 'pl.pl_target_id = lt.lt_id' );
-				$this->queryBuilder->leftJoin( 'page', 'page', [
+				$this->queryBuilder->leftJoin( 'page', null, [
 					'lt.lt_namespace = page.page_namespace',
 					'lt.lt_title = page.page_title',
 				] );

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -415,8 +415,7 @@ class Query {
 	 * @param bool $option @phan-unused-param
 	 */
 	private function _addcategories( bool $option ): void {
-		$this->queryBuilder->table( 'page' );
-		$this->queryBuilder->leftJoin( 'categorylinks', 'cl_gc', 'page.page_id = cl_gc.cl_from' );
+		$this->queryBuilder->leftJoin( 'categorylinks', 'cl_gc', 'page_id = cl_gc.cl_from' );
 		$this->queryBuilder->groupBy( 'page.page_id' );
 
 		$dbType = $this->dbr->getType();

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -415,6 +415,7 @@ class Query {
 	 * @param bool $option @phan-unused-param
 	 */
 	private function _addcategories( bool $option ): void {
+		$this->queryBuilder->table( 'page' );
 		$this->queryBuilder->leftJoin( 'categorylinks', 'cl_gc', 'page.page_id = cl_gc.cl_from' );
 		$this->queryBuilder->groupBy( 'page.page_id' );
 


### PR DESCRIPTION
Ensure conflict error is still given when using `openreferences = missing`.