### PR TITLE
Refactor parameter handling to replace `__call()` magic with `processParameter()`

### DIFF
--- a/includes/Parameters.php
+++ b/includes/Parameters.php
@@ -147,7 +147,7 @@ class Parameters extends ParametersData {
 		}
 
 		// Page name list
-		if ( ( $parameterData['page_name_list'] ?? false ) ) {
+		if ( $parameterData['page_name_list'] ?? false ) {
 			$pageGroups = $this->getParameter( $parameter ) ?? [];
 			$pages = $this->getPageNameList( $option,
 				(bool)( $parameterData['page_name_must_exist'] ?? false )

--- a/includes/Parameters.php
+++ b/includes/Parameters.php
@@ -59,19 +59,16 @@ class Parameters extends ParametersData {
 		$this->setDefaults();
 	}
 
-	/**
-	 * Handle simple parameter functions.
-	 */
-	public function __call( string $parameter, array $arguments ): bool {
+	public function processParameter( string $parameter, string $option ): bool {
 		$parameterData = $this->getData( $parameter );
 		if ( $parameterData === false ) {
 			return false;
 		}
 
-		$function = '_' . $parameter;
+		$method = '_' . $parameter;
 		$this->parametersProcessed[$parameter] = true;
-		if ( method_exists( $this, $function ) ) {
-			return $this->$function( ...$arguments );
+		if ( method_exists( $this, $method ) ) {
+			return $this->$method( $option );
 		}
 
 		$option = $arguments[0];
@@ -360,7 +357,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'category' parameter.
 	 */
-	public function _category( string $option ): bool {
+	private function _category( string $option ): bool {
 		$option = trim( html_entity_decode( $option, ENT_QUOTES ) );
 		if ( $option === '' ) {
 			return false;
@@ -443,7 +440,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'categoryregexp' parameter.
 	 */
-	public function _categoryregexp( string $option ): bool {
+	private function _categoryregexp( string $option ): bool {
 		if ( !$this->isRegexValid( [ $option ], forDb: true ) ) {
 			return false;
 		}
@@ -462,7 +459,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'categorymatch' parameter.
 	 */
-	public function _categorymatch( string $option ): bool {
+	private function _categorymatch( string $option ): bool {
 		[ $newMatches, $operator ] = str_contains( $option, '|' )
 			? [ explode( '|', $option ), 'OR' ]
 			: [ explode( '<&>', $option ), 'AND' ];
@@ -480,7 +477,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'notcategory' parameter.
 	 */
-	public function _notcategory( string $option ): bool {
+	private function _notcategory( string $option ): bool {
 		$title = Title::newFromText( $option );
 		if ( $title === null ) {
 			return false;
@@ -498,7 +495,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'notcategoryregexp' parameter.
 	 */
-	public function _notcategoryregexp( string $option ): bool {
+	private function _notcategoryregexp( string $option ): bool {
 		if ( !$this->isRegexValid( [ $option ], forDb: true ) ) {
 			return false;
 		}
@@ -515,7 +512,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'notcategorymatch' parameter.
 	 */
-	public function _notcategorymatch( string $option ): bool {
+	private function _notcategorymatch( string $option ): bool {
 		$data = $this->getParameter( 'notcategory' ) ?? [];
 		$data[IExpression::LIKE] ??= [];
 
@@ -531,7 +528,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'count' parameter.
 	 */
-	public function _count( string|int $option ): bool {
+	private function _count( string|int $option ): bool {
 		if ( !is_numeric( $option ) || (int)$option <= 0 ) {
 			return false;
 		}
@@ -546,7 +543,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'namespace' parameter.
 	 */
-	public function _namespace( string $option ): bool {
+	private function _namespace( string $option ): bool {
 		$contLang = MediaWikiServices::getInstance()->getContentLanguage();
 		$allowedNamespaces = $this->config->get( 'allowedNamespaces' );
 		$data = $this->getParameter( 'namespace' ) ?? [];
@@ -586,7 +583,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'notnamespace' parameter.
 	 */
-	public function _notnamespace( string $option ): bool {
+	private function _notnamespace( string $option ): bool {
 		$contLang = MediaWikiServices::getInstance()->getContentLanguage();
 		$data = $this->getParameter( 'notnamespace' ) ?? [];
 		foreach ( explode( '|', $option ) as $parameter ) {
@@ -620,7 +617,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'openreferences' parameter.
 	 */
-	public function _openreferences( string $option ): bool {
+	private function _openreferences( string $option ): bool {
 		if ( $option !== 'missing' ) {
 			$option = $this->filterBoolean( $option );
 		}
@@ -639,7 +636,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'ordermethod' parameter.
 	 */
-	public function _ordermethod( string $option ): bool {
+	private function _ordermethod( string $option ): bool {
 		$methods = array_map( 'trim', explode( ',', $option ) );
 		$validMethods = $this->getData( 'ordermethod' )['values'] ?? [];
 		foreach ( $methods as $method ) {
@@ -659,7 +656,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'mode' parameter.
 	 */
-	public function _mode( string $option ): bool {
+	private function _mode( string $option ): bool {
 		if ( !in_array( $option, $this->getData( 'mode' )['values'] ?? [], true ) ) {
 			return false;
 		}
@@ -683,7 +680,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'distinct' parameter.
 	 */
-	public function _distinct( string $option ): bool {
+	private function _distinct( string $option ): bool {
 		if ( $option === 'strict' ) {
 			$this->setParameter( 'distinctresultset', 'strict' );
 			return true;
@@ -701,7 +698,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'ordercollation' parameter.
 	 */
-	public function _ordercollation( string $option ): bool {
+	private function _ordercollation( string $option ): bool {
 		if ( $option === 'bridge' ) {
 			$this->setParameter( 'ordersuitsymbols', true );
 			return true;
@@ -718,14 +715,14 @@ class Parameters extends ParametersData {
 	/**
 	 * Shortcut to _format().
 	 */
-	public function _listseparators( string $option ): bool {
+	private function _listseparators( string $option ): bool {
 		return $this->_format( $option );
 	}
 
 	/**
 	 * Clean and test 'format' parameter.
 	 */
-	public function _format( string $option ): bool {
+	private function _format( string $option ): bool {
 		// Parsing of wikitext will happen at the end of the output phase.
 		// Replace '\n' in the input by linefeed because wiki syntax
 		// depends on linefeeds.
@@ -744,7 +741,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'title' parameter.
 	 */
-	public function _title( string $option ): bool {
+	private function _title( string $option ): bool {
 		$title = Title::newFromText( $option );
 		if ( !$title ) {
 			return false;
@@ -769,7 +766,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'titlemaxlength' parameter.
 	 */
-	public function _titlemaxlength( string $option ): bool {
+	private function _titlemaxlength( string $option ): bool {
 		$this->setParameter( 'titlemaxlen', (int)$option );
 		return true;
 	}
@@ -777,7 +774,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'titleregexp' parameter.
 	 */
-	public function _titleregexp( string $option ): bool {
+	private function _titleregexp( string $option ): bool {
 		$data = $this->getParameter( 'title' ) ?? [];
 		$data['REGEXP'] ??= [];
 
@@ -797,7 +794,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'titlematch' parameter.
 	 */
-	public function _titlematch( string $option ): bool {
+	private function _titlematch( string $option ): bool {
 		$data = $this->getParameter( 'title' ) ?? [];
 		$data[IExpression::LIKE] ??= [];
 
@@ -813,7 +810,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'nottitleregexp' parameter.
 	 */
-	public function _nottitleregexp( string $option ): bool {
+	private function _nottitleregexp( string $option ): bool {
 		$data = $this->getParameter( 'nottitle' ) ?? [];
 		$data['REGEXP'] ??= [];
 
@@ -833,7 +830,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'nottitlematch' parameter.
 	 */
-	public function _nottitlematch( string $option ): bool {
+	private function _nottitlematch( string $option ): bool {
 		$data = $this->getParameter( 'nottitle' ) ?? [];
 		$data[IExpression::LIKE] ??= [];
 
@@ -849,7 +846,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'scroll' parameter.
 	 */
-	public function _scroll( string $option ): bool {
+	private function _scroll( string $option ): bool {
 		$option = $this->filterBoolean( $option );
 		$this->setParameter( 'scroll', $option );
 
@@ -884,7 +881,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'replaceintitle' parameter.
 	 */
-	public function _replaceintitle( string $option ): bool {
+	private function _replaceintitle( string $option ): bool {
 		// We offer a possibility to replace some part of the title
 		$replaceInTitle = explode( ',', $option, 2 );
 		if ( isset( $replaceInTitle[1] ) ) {
@@ -898,7 +895,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'debug' parameter.
 	 */
-	public function _debug( string $option ): bool {
+	private function _debug( string $option ): bool {
 		if ( !is_numeric( $option ) ) {
 			return false;
 		}
@@ -915,14 +912,14 @@ class Parameters extends ParametersData {
 	/**
 	 * Shortcut to _include().
 	 */
-	public function _includepage( string $option ): bool {
+	private function _includepage( string $option ): bool {
 		return $this->_include( $option );
 	}
 
 	/**
 	 * Clean and test 'include' parameter.
 	 */
-	public function _include( string $option ): bool {
+	private function _include( string $option ): bool {
 		if ( $option === '' ) {
 			return false;
 		}
@@ -936,7 +933,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'includematch' parameter.
 	 */
-	public function _includematch( string $option ): bool {
+	private function _includematch( string $option ): bool {
 		$regexes = explode( ',', $option );
 		if ( !$this->isRegexValid( $regexes, forDb: false ) ) {
 			return false;
@@ -949,7 +946,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'includemaxlength' parameter.
 	 */
-	public function _includemaxlength( string $option ): bool {
+	private function _includemaxlength( string $option ): bool {
 		if ( !is_numeric( $option ) ) {
 			return false;
 		}
@@ -961,7 +958,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'includematchparsed' parameter.
 	 */
-	public function _includematchparsed( string $option ): bool {
+	private function _includematchparsed( string $option ): bool {
 		$regexes = explode( ',', $option );
 		if ( !$this->isRegexValid( $regexes, forDb: false ) ) {
 			return false;
@@ -975,7 +972,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'includenotmatch' parameter.
 	 */
-	public function _includenotmatch( string $option ): bool {
+	private function _includenotmatch( string $option ): bool {
 		$regexes = explode( ',', $option );
 		if ( !$this->isRegexValid( $regexes, forDb: false ) ) {
 			return false;
@@ -988,7 +985,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'includenotmatchparsed' parameter.
 	 */
-	public function _includenotmatchparsed( string $option ): bool {
+	private function _includenotmatchparsed( string $option ): bool {
 		$regexes = explode( ',', $option );
 		if ( !$this->isRegexValid( $regexes, forDb: false ) ) {
 			return false;
@@ -1002,7 +999,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'secseparators' parameter.
 	 */
-	public function _secseparators( string $option ): bool {
+	private function _secseparators( string $option ): bool {
 		// We replace '\n' by newline to support wiki syntax within the section separators
 		$this->setParameter( 'secseparators', explode( ',', Parse::replaceNewLines( $option ) ) );
 		return true;
@@ -1011,7 +1008,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'multisecseparators' parameter.
 	 */
-	public function _multisecseparators( string $option ): bool {
+	private function _multisecseparators( string $option ): bool {
 		// We replace '\n' by newline to support wiki syntax within the section separators
 		$this->setParameter( 'multisecseparators', explode( ',', Parse::replaceNewLines( $option ) ) );
 		return true;
@@ -1020,7 +1017,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'table' parameter.
 	 */
-	public function _table( string $option ): bool {
+	private function _table( string $option ): bool {
 		$this->setParameter( 'defaulttemplatesuffix', '' );
 		$this->setParameter( 'mode', 'userformat' );
 		$this->setParameter( 'inlinetext', '' );
@@ -1086,7 +1083,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'tablerow' parameter.
 	 */
-	public function _tablerow( string $option ): bool {
+	private function _tablerow( string $option ): bool {
 		$option = Parse::replaceNewLines( trim( $option ) );
 		$this->setParameter( 'tablerow', $option === '' ? [] : explode( ',', $option ) );
 		return true;
@@ -1096,7 +1093,7 @@ class Parameters extends ParametersData {
 	 * Clean and test 'allowcachedresults' parameter.
 	 * This function is necessary for the custom 'yes+warn' option that sets 'warncachedresults'.
 	 */
-	public function _allowcachedresults( string $option ): bool {
+	private function _allowcachedresults( string $option ): bool {
 		// If execAndExit was previously set (i.e. if it is not empty) we will ignore all
 		// cache settings which are placed AFTER the execandexit statement thus we make sure
 		// that the cache will only become invalid if the query is really executed.
@@ -1123,7 +1120,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'fixcategory' parameter.
 	 */
-	public function _fixcategory( string $option ): bool {
+	private function _fixcategory( string $option ): bool {
 		Utils::fixCategory( $option );
 		return true;
 	}
@@ -1131,7 +1128,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'reset' parameter.
 	 */
-	public function _reset( string $option ): bool {
+	private function _reset( string $option ): bool {
 		$arguments = array_map( 'trim', explode( ',', $option ) );
 		$values = $this->getData( 'reset' )['values'] ?? [];
 		$reset = [];
@@ -1165,7 +1162,7 @@ class Parameters extends ParametersData {
 	/**
 	 * Clean and test 'eliminate' parameter.
 	 */
-	public function _eliminate( string $option ): bool {
+	private function _eliminate( string $option ): bool {
 		$arguments = array_map( 'trim', explode( ',', $option ) );
 		$values = $this->getData( 'eliminate' )['values'] ?? [];
 		$eliminate = [];

--- a/includes/Parse.php
+++ b/includes/Parse.php
@@ -160,7 +160,7 @@ class Parse {
 			foreach ( $options as $option ) {
 				// Parameter functions return true or false. The full parameter data will be
 				// passed into the Query object later.
-				if ( !$this->parameters->$parameter( $option ) ) {
+				if ( !$this->parameters->processParameter( $parameter, $option ) ) {
 					// Do not build this into the output just yet. It will be collected at the end.
 					$this->logger->addMessage( Constants::WARN_WRONGPARAM, $parameter, $option );
 				}

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -103,10 +103,10 @@ class Query {
 				continue;
 			}
 
-			$function = '_' . $parameter;
+			$method = '_' . $parameter;
 			// Some parameters do not modify the query so we check if the function to modify the query exists first.
-			if ( method_exists( $this, $function ) ) {
-				$this->$function( $option );
+			if ( method_exists( $this, $method ) ) {
+				$this->$method( $option );
 			}
 
 			$this->parametersProcessed[$parameter] = true;


### PR DESCRIPTION
This took an unreasonable amount of time to trace. `Parse` was calling methods on
`Parameters` that didn’t even exist (e.g. `$this->count()`), assuming they’d just
magically work. These calls silently funneled into `__call()`, which handled filtering,
transformation, and then dispatched to the actual method — conveniently hiding under
an underscore like it was in witness protection (e.g. `_count()`).

It was chaotic, indirect, and entirely too clever for its own good.

This refactor replaces all of that with a real method: `processParameter()`.
Now parameter logic is explicit, readable, and doesn’t require a multi-hour
archaeological dig to understand.