### PR TITLE
Optimize query for ordermethod=lastedit

### DIFF
--- a/includes/Query.php
+++ b/includes/Query.php
@@ -2019,9 +2019,7 @@ class Query {
 								);
 							} else {
 								$this->addWhere(
-									'rev.rev_timestamp = (SELECT MAX(rev_aux.rev_timestamp) FROM ' .
-									$this->dbr->tableName( 'revision' ) .
-									' AS rev_aux WHERE rev_aux.rev_page = rev.rev_page)'
+									"rev.rev_id = {$this->dbr->tableName( 'page' )}.page_latest"
 								);
 							}
 						}


### PR DESCRIPTION
This particular order method is trying to get the last edit from the revision table, ordering by timestamp, which is a lot more costly than simply using the page_touched field, which points to the latest revision of the page, and it's a lot cheaper to compute.