### PR TITLE
Make parser function arguments optional to prevent errors

### DIFF
--- a/includes/HookHandlers/Main.php
+++ b/includes/HookHandlers/Main.php
@@ -245,7 +245,7 @@ class Main implements ParserFirstCallInitHook {
 	public function dplReplaceParserFunction(
 		Parser $parser,
 		string $text,
-		string $pat,
+		string $pat = '',
 		string $repl = ''
 	): string {
 		$parser->addTrackingCategory( 'dplreplace-parserfunc-tracking-category' );
@@ -306,11 +306,11 @@ class Main implements ParserFirstCallInitHook {
 
 	public function dplMatrixParserFunction(
 		Parser $parser,
-		string $name,
-		string $yes,
-		string $no,
-		string $flip,
-		string $matrix
+		string $name = '',
+		string $yes = '',
+		string $no = '',
+		string $flip = '',
+		string $matrix = ''
 	): string {
 		$parser->addTrackingCategory( 'dplmatrix-parserfunc-tracking-category' );
 


### PR DESCRIPTION
Fixes ArgumentCountError: Too few arguments to function MediaWiki\\Extension\\DynamicPageList4\\HookHandlers\\Main::dplReplaceParserFunction(), 2 passed