### PR TITLE
Fix fatal error when moving some pages

### DIFF
--- a/includes/SectionTranscluder.php
+++ b/includes/SectionTranscluder.php
@@ -554,8 +554,8 @@ class SectionTranscluder {
 		$page = $title->getPrefixedText();
 
 		$text = '';
-        if ( !self::text( $parser, $page, $text ) ) {
-            return [ $text ];
+		if ( !self::text( $parser, $page, $text ) ) {
+			return [ $text ];
 		}
 
 		$date = $article->myDate;


### PR DESCRIPTION
When you move other pages shown in the include at the same time, then those pages can not be read as existing anymore leading to fatal errors.