### PR TITLE
Fix collation issue when using LOWER with REGEXP

### DIFF
--- a/includes/Query.php
+++ b/includes/Query.php
@@ -444,7 +444,7 @@ class Query {
 		}
 
 		if ( $dbType === 'mysql' ) {
-			$fieldExpr = "LOWER(CAST($field AS CHAR CHARACTER SET utf8mb4))";
+			$fieldExpr = "LOWER(" . $this->applyCollation( $field ) . ")";
 			if ( $operator === 'REGEXP' ) {
 				return $this->buildRegexpExpression( $fieldExpr, $value );
 			}


### PR DESCRIPTION
When using `REGEXP` (e.g `titleregexp` in a DPL invocation)  in combination with `LOWER` (e.g `ignorecase` in a DPL invocation), the following error is received:

```
[DynamicPageList4] Query error at MediaWiki\Extension\DynamicPageList4\Query::buildAndSelect - Dpl: Error 3995: Character set 'utf8mb4_0900_ai_ci' cannot be used in conjunction with 'binary' in call to regexp_like.
Function: MediaWiki\Extension\DynamicPageList4\Query::buildAndSelect - Dpl
Query: SELECT /*+ MAX_EXECUTION_TIME(10000)*/ DISTINCT p.page_namespace AS `page_namespace`,p.page_id AS `page_id`,p.page_title AS `page_title`  FROM `page` `p`    WHERE ((LOWER(CAST(p.page_title AS CHAR CHARACTER SET utf8mb4)) REGEXP '(.*[cc]aves*_[(]+)') OR (LOWER(CAST(p.page_title AS CHAR CHARACTER SET utf8mb4)) REGEXP '(.*[cc]aves*$)')) AND p.page_is_redirect = 0  LIMIT 500  
```

This PR fixes this issue by using the correct collation.