### PR TITLE
Preserve case for userdateformat parameter

### DIFF
--- a/includes/ParametersData.php
+++ b/includes/ParametersData.php
@@ -856,6 +856,7 @@ class ParametersData {
 		'userdateformat' => [
 			'default' => 'Y-m-d H:i:s',
 			'strip_html' => true,
+			'preserve_case' => true,
 		],
 
 		/**


### PR DESCRIPTION
The format characters are case sensitive.
This fixes a regression introduced in DPL4.